### PR TITLE
Add Home Manager module

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,49 @@ Download binaries for various operating systems and architectures from the [rele
    $ mkdir -p ~/bin && cp target/release/ssh-agent-mux ~/bin/
    ```
 
+### Home Manager (Nix)
+
+This flake exposes a [Home Manager](https://nix-community.github.io/home-manager/)
+module that renders the config file and runs the mux as a user service (systemd
+`--user` on Linux, a launchd agent on macOS).
+
+Add the flake as an input and import the module:
+
+```nix
+{
+  inputs.ssh-agent-mux.url = "github:overhacked/ssh-agent-mux";
+
+  # In your Home Manager configuration:
+  imports = [ inputs.ssh-agent-mux.homeManagerModules.default ];
+
+  services.ssh-agent-mux = {
+    enable = true;
+    # Export SSH_AUTH_SOCK so SSH clients use the mux by default.
+    enableSshAuthSock = true;
+
+    agents = [
+      {
+        name = "1password";
+        socketPath = "~/.1password/agent.sock";
+      }
+      {
+        name = "yubikey";
+        socketPath = "~/.ssh/yubikey-agent.sock";
+      }
+    ];
+
+    # Forward `ssh-add` requests to a specific agent (optional).
+    addNewKeysTo = "1password";
+  };
+}
+```
+
+Available options: `enable`, `package`, `listenPath`, `agents` (`name`,
+`socketPath`, `enabled`), `addNewKeysTo`, `logLevel`, `logFile`, `agentTimeout`,
+`installService`, `enableSshAuthSock`, and a freeform `settings` escape hatch.
+Because the module manages the service declaratively, the imperative
+`ssh-agent-mux service install` / `config install` subcommands are not needed.
+
 ## Usage
 
 ### Linux (systemd)

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,15 @@
       tap,
       treefmt-nix,
     }:
-    utils.lib.eachDefaultSystem (
+    # System-agnostic outputs (Home Manager module) merged with the per-system
+    # outputs produced by eachDefaultSystem below.
+    {
+      homeManagerModules = rec {
+        ssh-agent-mux = import ./nix/home-manager.nix self;
+        default = ssh-agent-mux;
+      };
+    }
+    // utils.lib.eachDefaultSystem (
       system:
       let
         pkgs = import nixpkgs {

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -1,0 +1,242 @@
+# Home Manager module for ssh-agent-mux.
+#
+# Exposed from the flake as `homeManagerModules.ssh-agent-mux` (and
+# `.default`). It writes the TOML config to
+# `~/.config/ssh-agent-mux/ssh-agent-mux.toml` and, by default, runs the mux as
+# a user service (systemd `--user` on Linux, launchd agent on macOS).
+#
+# Unlike `ssh-agent-mux service install`, this manages the unit declaratively
+# through Home Manager, so the imperative `service`/`config` subcommands are not
+# needed when using this module.
+self:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.ssh-agent-mux;
+
+  tomlFormat = pkgs.formats.toml { };
+
+  # Path of the rendered config file once Home Manager has linked it into XDG.
+  configPath = "${config.xdg.configHome}/ssh-agent-mux/ssh-agent-mux.toml";
+
+  # Structured options -> the kebab-case keys the binary's serde config expects.
+  # Nulls are dropped so they fall back to the binary's own defaults, and any
+  # `settings` escape-hatch keys are layered on top.
+  baseSettings = lib.filterAttrs (_: v: v != null) {
+    listen-path = cfg.listenPath;
+    log-level = cfg.logLevel;
+    log-file = cfg.logFile;
+    agent-timeout = cfg.agentTimeout;
+    add-new-keys-to = cfg.addNewKeysTo;
+    agents = map (a: {
+      inherit (a) name enabled;
+      socket-path = a.socketPath;
+    }) cfg.agents;
+  };
+
+  finalSettings = lib.recursiveUpdate baseSettings cfg.settings;
+
+  configFile = tomlFormat.generate "ssh-agent-mux.toml" finalSettings;
+
+  agentNames = map (a: a.name) cfg.agents;
+  enabledAgentNames = map (a: a.name) (lib.filter (a: a.enabled) cfg.agents);
+
+  agentModule = lib.types.submodule {
+    options = {
+      name = lib.mkOption {
+        type = lib.types.str;
+        example = "1password";
+        description = "Unique name identifying this upstream agent.";
+      };
+
+      socketPath = lib.mkOption {
+        type = lib.types.str;
+        example = "~/.1password/agent.sock";
+        description = ''
+          Path to the upstream agent's listening socket. Supports `~` and
+          `''${VAR}` expansion, performed by ssh-agent-mux itself.
+        '';
+      };
+
+      enabled = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Whether keys from this agent are offered through the mux.";
+      };
+    };
+  };
+in
+{
+  options.services.ssh-agent-mux = {
+    enable = lib.mkEnableOption "ssh-agent-mux, an SSH agent multiplexer";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+      defaultText = lib.literalExpression "ssh-agent-mux.packages.\${system}.default";
+      description = "The ssh-agent-mux package to use.";
+    };
+
+    listenPath = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.xdg.stateHome}/ssh-agent-mux/agent.sock";
+      defaultText = lib.literalExpression ''"''${config.xdg.stateHome}/ssh-agent-mux/agent.sock"'';
+      description = ''
+        Socket path that ssh-agent-mux listens on. Point your SSH client's
+        `SSH_AUTH_SOCK` / `IdentityAgent` at this path (or set
+        {option}`services.ssh-agent-mux.enableSshAuthSock`).
+      '';
+    };
+
+    agents = lib.mkOption {
+      type = lib.types.listOf agentModule;
+      default = [ ];
+      example = lib.literalExpression ''
+        [
+          {
+            name = "1password";
+            socketPath = "~/.1password/agent.sock";
+          }
+          {
+            name = "yubikey";
+            socketPath = "~/.ssh/yubikey-agent.sock";
+          }
+        ]
+      '';
+      description = ''
+        Upstream SSH agents to multiplex. The order keys are offered to a server
+        follows the order of this list.
+      '';
+    };
+
+    addNewKeysTo = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "1password";
+      description = ''
+        Name of the agent (from {option}`services.ssh-agent-mux.agents`) that
+        `ssh-add` / add-identity requests are forwarded to. When `null`, adding
+        keys through the mux fails.
+      '';
+    };
+
+    logLevel = lib.mkOption {
+      type = lib.types.enum [
+        "error"
+        "warn"
+        "info"
+        "debug"
+        "trace"
+      ];
+      default = "warn";
+      description = "Log verbosity for ssh-agent-mux.";
+    };
+
+    logFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "~/.local/state/ssh-agent-mux/agent.log";
+      description = "Optional file to log to. Logs to stdout when `null`.";
+    };
+
+    agentTimeout = lib.mkOption {
+      type = lib.types.ints.unsigned;
+      default = 5;
+      description = "Timeout, in seconds, for upstream agent operations.";
+    };
+
+    installService = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether to run ssh-agent-mux as a user service (systemd `--user` on
+        Linux, a launchd agent on macOS). Disable to only manage the config file
+        and package.
+      '';
+    };
+
+    enableSshAuthSock = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to export `SSH_AUTH_SOCK` (pointing at
+        {option}`services.ssh-agent-mux.listenPath`) as a session variable so
+        SSH clients use the mux by default.
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          log-level = "info";
+        }
+      '';
+      description = ''
+        Extra settings merged into the generated TOML config, using the binary's
+        kebab-case keys. Takes precedence over the structured options above; use
+        as an escape hatch for keys this module does not expose yet.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    {
+      assertions = [
+        {
+          assertion = lib.length (lib.unique agentNames) == lib.length agentNames;
+          message = "services.ssh-agent-mux.agents: agent names must be unique.";
+        }
+        {
+          assertion = cfg.addNewKeysTo == null || lib.elem cfg.addNewKeysTo enabledAgentNames;
+          message =
+            "services.ssh-agent-mux.addNewKeysTo must reference the name of an "
+            + "enabled agent in services.ssh-agent-mux.agents.";
+        }
+      ];
+
+      home.packages = [ cfg.package ];
+
+      xdg.configFile."ssh-agent-mux/ssh-agent-mux.toml".source = configFile;
+
+      home.sessionVariables = lib.mkIf cfg.enableSshAuthSock {
+        SSH_AUTH_SOCK = cfg.listenPath;
+      };
+    }
+
+    (lib.mkIf (cfg.installService && pkgs.stdenv.hostPlatform.isLinux) {
+      systemd.user.services.ssh-agent-mux = {
+        Unit = {
+          Description = "SSH Agent Multiplexer";
+          After = [ "graphical-session-pre.target" ];
+        };
+        Service = {
+          ExecStart = "${cfg.package}/bin/ssh-agent-mux --config ${configPath}";
+          ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+          Restart = "on-failure";
+        };
+        Install.WantedBy = [ "default.target" ];
+      };
+    })
+
+    (lib.mkIf (cfg.installService && pkgs.stdenv.hostPlatform.isDarwin) {
+      launchd.agents.ssh-agent-mux = {
+        enable = true;
+        config = {
+          ProgramArguments = [
+            "${cfg.package}/bin/ssh-agent-mux"
+            "--config"
+            configPath
+          ];
+          KeepAlive = true;
+          RunAtLoad = true;
+        };
+      };
+    })
+  ]);
+}


### PR DESCRIPTION
Expose a Home Manager module via the flake's homeManagerModules output
that renders the TOML config to ~/.config/ssh-agent-mux/ and runs the mux
as a user service (systemd --user on Linux, launchd agent on macOS).

Provides structured options for agents, listen path, logging, add-new-keys
forwarding, an optional SSH_AUTH_SOCK session variable, and a freeform
settings escape hatch. Includes assertions mirroring the binary's config
validation (unique agent names, add-new-keys-to references an enabled agent).

https://claude.ai/code/session_01D8dz7SrTAn9FYQPNTEq7iH